### PR TITLE
Implement basic biomarker upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,14 @@ pnpm dev:client    # Next.js frontend
 pnpm dev:server    # Express backend
 ```
 
+## Biomarker Tracking
+
+Seed the database with initial biomarkers:
+
+```bash
+pnpm --filter server run seed
+```
+
+Start the app and visit the client at `http://localhost:3000` to upload lab reports.
+
 See `AGENTS.md` for contributor guidelines.

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -1,3 +1,29 @@
+import { useState } from 'react';
+
 export default function Home() {
-  return <div className="p-4 text-center">Hello from Next.js</div>;
+  const [file, setFile] = useState<File | null>(null);
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('http://localhost:3001/api/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    const data = await res.json();
+    setMessage(JSON.stringify(data));
+  };
+
+  return (
+    <div className="p-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">Upload</button>
+      </form>
+      {message && <pre>{message}</pre>}
+    </div>
+  );
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,14 +5,18 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
-    "express": "latest"
+    "express": "latest",
+    "multer": "latest",
+    "@prisma/client": "latest"
   },
   "devDependencies": {
     "typescript": "latest",
     "ts-node": "latest",
-    "@types/express": "latest"
+    "@types/express": "latest",
+    "prisma": "latest"
   }
 }

--- a/packages/server/prisma/biomarkers.json
+++ b/packages/server/prisma/biomarkers.json
@@ -1,0 +1,78 @@
+[
+    {
+        "name": "% Transferrin Saturation",
+        "category": "Iron Studies",
+        "unit": "%",
+        "description": "Percentage of transferrin iron\u2011binding sites that are occupied by iron.",
+        "optimalRangeLow": 20,
+        "optimalRangeHigh": 50,
+        "warningLow": 15,
+        "warningHigh": 50,
+        "criticalLow": 10,
+        "criticalHigh": 90,
+        "measurementType": "percentage",
+        "importance": 8,
+        "details": "Transferrin saturation is calculated as (serum iron \u00f7 total iron\u2010binding capacity) \u00d7 100 and is used to assess iron status; values <20% suggest deficiency and >50% suggest overload.",
+        "referenceUrl": "https://emedicine.medscape.com/article/2087960-overview",
+        "conditionalRanges": [
+            {
+                "condition": "Children (1-10 years)",
+                "optimalRangeLow": 22,
+                "optimalRangeHigh": 39
+            },
+            {
+                "condition": "Adolescents (10-18 years)",
+                "optimalRangeLow": 27,
+                "optimalRangeHigh": 44
+            },
+            {
+                "condition": "Newborn",
+                "optimalRangeLow": 56,
+                "optimalRangeHigh": 74
+            }
+        ]
+    },
+    {
+        "name": "17-hydroxyprogesterone",
+        "category": "Hormones / Endocrine",
+        "unit": "ng/dL",
+        "description": "A steroid hormone produced by the adrenal cortex and gonads; a precursor in the biosynthesis of cortisol and androgenic steroids.",
+        "measurementType": "numeric",
+        "importance": 7,
+        "optimalRangeLow": 27,
+        "optimalRangeHigh": 199,
+        "warningLow": 20,
+        "warningHigh": 300,
+        "criticalLow": 10,
+        "criticalHigh": 1000,
+        "details": "Used primarily to screen for congenital adrenal hyperplasia (CAH) due to 21-hydroxylase deficiency; levels vary by age, sex, and menstrual cycle phase.",
+        "referenceUrl": "https://emedicine.medscape.com/article/242270-overview",
+        "conditionalRanges": [
+            {
+                "condition": "Newborn",
+                "optimalRangeLow": 0,
+                "optimalRangeHigh": 400
+            },
+            {
+                "condition": "Children",
+                "optimalRangeLow": 0,
+                "optimalRangeHigh": 110
+            },
+            {
+                "condition": "Adult Male",
+                "optimalRangeLow": 27,
+                "optimalRangeHigh": 199
+            },
+            {
+                "condition": "Adult Female (Follicular phase)",
+                "optimalRangeLow": 20,
+                "optimalRangeHigh": 100
+            },
+            {
+                "condition": "Adult Female (Luteal phase)",
+                "optimalRangeLow": 100,
+                "optimalRangeHigh": 300
+            }
+        ]
+    }
+]

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -6,3 +6,32 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
 }
+
+model Biomarker {
+  id                Int     @id @default(autoincrement())
+  name              String  @unique
+  unit              String?
+  category          String?
+  description       String?
+  measurementType   String?
+  importance        Int?
+  optimalRangeLow   Float?
+  optimalRangeHigh  Float?
+  results           BiomarkerResult[]
+}
+
+model LabReport {
+  id         Int     @id @default(autoincrement())
+  filePath   String
+  createdAt  DateTime @default(now())
+  results    BiomarkerResult[]
+}
+
+model BiomarkerResult {
+  id          Int     @id @default(autoincrement())
+  value       Float
+  biomarker   Biomarker @relation(fields: [biomarkerId], references: [id])
+  biomarkerId Int
+  report      LabReport @relation(fields: [reportId], references: [id])
+  reportId    Int
+}

--- a/packages/server/prisma/seed.ts
+++ b/packages/server/prisma/seed.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+import data from './biomarkers.json';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  for (const b of (data as any[])) {
+    await prisma.biomarker.upsert({
+      where: { name: b.name },
+      update: {},
+      create: {
+        name: b.name,
+        unit: b.unit,
+        category: b.category,
+        description: b.description,
+        measurementType: b.measurementType,
+        importance: b.importance,
+        optimalRangeLow: b.optimalRangeLow,
+        optimalRangeHigh: b.optimalRangeHigh,
+      },
+    });
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+}).finally(() => prisma.$disconnect());

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,43 @@
 import express from 'express';
+import multer from 'multer';
+import { PrismaClient } from '@prisma/client';
+import fs from 'fs/promises';
 
+const prisma = new PrismaClient();
 const app = express();
+const upload = multer({ dest: 'uploads/' });
 const port = process.env.PORT || 3001;
+
+app.use(express.json());
 
 app.get('/api/hello', (_, res) => {
   res.json({ message: 'Hello from Express' });
+});
+
+async function mockGeminiExtract(text: string) {
+  // TODO: integrate Gemini API. Returns [{ name: biomarkerName, value: number }]
+  return [];
+}
+
+app.post('/api/upload', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'File required' });
+  }
+  const content = await fs.readFile(req.file.path, 'utf-8');
+  const values = await mockGeminiExtract(content);
+  const report = await prisma.labReport.create({ data: { filePath: req.file.path } });
+  for (const v of values) {
+    const biomarker = await prisma.biomarker.findUnique({ where: { name: v.name } });
+    if (!biomarker) continue;
+    await prisma.biomarkerResult.create({
+      data: {
+        value: v.value,
+        biomarkerId: biomarker.id,
+        reportId: report.id,
+      },
+    });
+  }
+  res.json({ success: true, reportId: report.id });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add Prisma schema and biomarker seed
- store biomarkers in prisma seed JSON
- implement upload API with Express, Multer and Prisma
- add basic upload form in Next.js client
- document biomarker workflow in README

## Testing
- `pnpm -r build` *(fails: next not found, no network)*