### PR TITLE
Add Prisma postinstall

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "express": "latest",


### PR DESCRIPTION
## Summary
- add postinstall script to generate Prisma client automatically

## Testing
- `pnpm install` *(fails: EHOSTUNREACH when Prisma tries to fetch binaries)*