### PR TITLE
Add Tailwind PostCSS plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ pnpm-lock.yaml
 .DS_Store
 dist
 .next
+node-compile-cache
 packages/server/.env
 packages/server/uploads/

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "@types/react": "19.1.4",
     "autoprefixer": "latest",
     "postcss": "latest",
+    "@tailwindcss/postcss": "latest",
     "tailwindcss": "latest",
     "typescript": "latest"
   }

--- a/packages/client/postcss.config.js
+++ b/packages/client/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {}
   }
 };


### PR DESCRIPTION
## Summary
- add `@tailwindcss/postcss` to client dev deps
- configure PostCSS to use the new plugin
- ignore node-compile-cache

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@tailwindcss%2Fpostcss error (EHOSTUNREACH))*