### PR TITLE
Load env automatically in server scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Configure environment variables by copying
 `packages/server/.env.example` to `packages/server/.env` and adjust
 the values for your local database connection.
 
+The server's `dev` and `seed` scripts automatically load this `.env` file
+using `dotenv`, so you don't need to configure it manually.
+
 Run the development servers:
 
 ```bash

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "main": "dist/index.js",
   "scripts": {
-    "dev": "ts-node src/index.ts",
+    "dev": "node -r dotenv/config node_modules/ts-node/dist/bin.js src/index.ts",
     "build": "tsc",
-    "seed": "ts-node prisma/seed.ts",
+    "seed": "node -r dotenv/config node_modules/ts-node/dist/bin.js prisma/seed.ts",
     "postinstall": "prisma generate"
   },
   "dependencies": {
@@ -19,6 +19,7 @@
     "ts-node": "latest",
     "@types/express": "latest",
     "prisma": "latest",
-    "@types/multer": "latest"
+    "@types/multer": "latest",
+    "dotenv": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- install `dotenv` as a dev dependency for the server package
- update server `dev` and `seed` scripts to preload dotenv
- mention automatic `.env` loading in the README

## Testing
- `pnpm --filter server run build`
- `pnpm install` *(fails: EHOSTUNREACH)*