### PR TITLE
Add simple report viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ pnpm --filter server run seed
 ```
 
 Start the app and visit the client at `http://localhost:3000` to upload lab reports.
+After uploading a report you will be given a link to view the parsed biomarker values.
 
 See `AGENTS.md` for contributor guidelines.

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import Link from 'next/link';
 
 export default function Home() {
   const [file, setFile] = useState<File | null>(null);
   const [message, setMessage] = useState('');
+  const [reportId, setReportId] = useState<number | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -14,7 +16,12 @@ export default function Home() {
       body: formData,
     });
     const data = await res.json();
-    setMessage(JSON.stringify(data));
+    if (data.reportId) {
+      setReportId(data.reportId);
+      setMessage('Upload successful');
+    } else {
+      setMessage(JSON.stringify(data));
+    }
   };
 
   return (
@@ -23,7 +30,13 @@ export default function Home() {
         <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
         <button type="submit" className="bg-blue-500 text-white px-4 py-2">Upload</button>
       </form>
-      {message && <pre>{message}</pre>}
+      {message && <p>{message}</p>}
+      {reportId && (
+        <p>
+          View report{' '}
+          <Link href={`/report/${reportId}`}>here</Link>
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/client/pages/report/[id].tsx
+++ b/packages/client/pages/report/[id].tsx
@@ -1,0 +1,49 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface Result {
+  id: number;
+  value: number;
+  biomarker: {
+    name: string;
+    unit: string | null;
+  };
+}
+
+interface Report {
+  id: number;
+  createdAt: string;
+  results: Result[];
+}
+
+export default function ReportPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [report, setReport] = useState<Report | null>(null);
+
+  useEffect(() => {
+    if (id) {
+      fetch(`http://localhost:3001/api/report/${id}`)
+        .then(res => res.json())
+        .then(setReport);
+    }
+  }, [id]);
+
+  if (!report) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-2">Report {report.id}</h1>
+      <ul className="list-disc ml-4">
+        {report.results.map(r => (
+          <li key={r.id}>
+            {r.biomarker.name}: {r.value}
+            {r.biomarker.unit ? ` ${r.biomarker.unit}` : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add text parser to server to populate biomarkers from uploaded files
- expose `/api/report/:id` for viewing results
- show report link in Next.js client and add report page
- mention report page in README

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm -r build`